### PR TITLE
docs(claude): anti-fabrication rules in CLAUDE.md; restore user template; embed evidence rules in generated CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,26 @@ When working on Agent OS itself:
 3. **Prove functionality** - Test changes with real Agent OS workflows
 4. **Document evidence** - Include command outputs in PR descriptions
 
+## CRITICAL: Verification Requirements (Anti‑fabrication)
+
+### NEVER simulate or fabricate results
+- When asked to analyze or compare files, you MUST show actual file contents or excerpts
+- When running ANY command, you MUST show the complete, actual terminal output
+- If a file doesn't exist, show the real error message from the system
+- If instructed to use subagents, you MUST actually invoke them, not simulate
+
+### Required workflow
+1. One command at a time — show full output before proceeding
+2. Verify file existence with `ls -la` (or equivalent) before reading/analyzing
+3. Use explicit tools for comparisons (e.g., `diff`, `git diff`) and paste excerpts
+4. Record evidence in the conversation or PR description
+
+### Forbidden behaviors
+- Claiming to have run commands without showing output
+- Summarizing file contents without showing actual data
+- Making up differences or improvements without concrete evidence
+- Ignoring explicit instructions about using specific subagents or tools
+
 Example verification:
 ```bash
 # After modifying setup.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,8 @@ When asked to work on Agent OS:
 
 1. **First**, check @.agent-os/product/roadmap.md for current priorities
 2. **Then**, follow the appropriate instruction file:
-   - For new features: @.agent-os/instructions/create-spec.md
-   - For tasks execution: @.agent-os/instructions/execute-tasks.md
+   - For new features: @.agent-os/instructions/core/create-spec.md
+   - For tasks execution: @.agent-os/instructions/core/execute-tasks.md
 3. **Always**, adhere to the standards in the files listed above
 
 ### Important Notes

--- a/claude-code/user/CLAUDE.md
+++ b/claude-code/user/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md (User-Level Template)
+
+This file configures Claude Code for all projects. Place at `~/.claude/CLAUDE.md`.
+
+## Project Context
+- Use project-local `CLAUDE.md` if present; otherwise apply these global rules.
+
+## CRITICAL: Verification Requirements (Anti‑fabrication)
+- ALWAYS show real command output for any command you claim to run.
+- When analyzing/comparing files, paste actual excerpts from those files.
+- If a file/path is missing, show the real error message from the system.
+- When steps specify `subagent="..."`, actually invoke that subagent.
+
+### Required workflow
+1. One command at a time; show full output before proceeding
+2. Verify file existence with `ls -la` before reading/analysis
+3. Use explicit tools for comparisons (e.g., `diff`, `git diff`) and paste excerpts
+4. Record evidence in the conversation or task report
+
+### Forbidden behaviors
+- Claiming to have executed commands without output
+- Summarizing file contents without excerpts
+- Making up differences or results without proof
+- Ignoring explicit instructions to use specific subagents/tools
+
+## Core Workflows
+- Plan product: `@~/.agent-os/instructions/core/plan-product.md`
+- Create spec: `@~/.agent-os/instructions/core/create-spec.md`
+- Execute tasks: `@~/.agent-os/instructions/core/execute-tasks.md`
+- Analyze product: `@~/.agent-os/instructions/core/analyze-product.md`
+
+## Standards
+- Code Style: `@~/.agent-os/standards/code-style.md`
+- Best Practices: `@~/.agent-os/standards/best-practices.md`
+
+

--- a/instructions/core/plan-product.md
+++ b/instructions/core/plan-product.md
@@ -618,6 +618,16 @@ When asked to work on this codebase:
 - Always adhere to established patterns, code style, and best practices documented above.
 </content_template>
 
+<evidence_requirements>
+  <critical>Anti-fabrication policy for this file</critical>
+  <rules>
+    - ALWAYS show real command output when referencing commands
+    - When comparing or analyzing files, paste actual excerpts
+    - If a file/path is missing, include the real error message
+    - When steps specify subagent="...", actually invoke that subagent
+  </rules>
+</evidence_requirements>
+
 <merge_behavior>
   <if_file_exists>
     <check_for_section>"## Agent OS Documentation"</check_for_section>


### PR DESCRIPTION
- Repo CLAUDE.md: added CRITICAL Verification Requirements (anti-fabrication) and forbidden behaviors\n- Project CLAUDE.md (plan-product Step 7): embedded evidence rules block\n- Restored user-level template at claude-code/user/CLAUDE.md with anti-fabrication policy\n\nValidation\n- Verified installers still reference user template paths\n- This PR addresses Issue #30 (evidence-first enforcement)\n