### PR TITLE
feat: /update-documentation core slash command + deterministic updater

### DIFF
--- a/commands/update-documentation.md
+++ b/commands/update-documentation.md
@@ -1,0 +1,26 @@
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(grep:*), Bash(sed:*), Bash(awk:*), Bash(~/.agent-os/scripts/update-documentation.sh:*)
+description: Update project documentation deterministically based on real diffs (discovery-first; evidence only)
+argument-hint: [--dry-run|--diff-only|--create-missing]
+---
+
+## Context
+
+- Current git status: !`git status --porcelain`
+- Changed files (head): !`git diff --name-only HEAD`
+
+## Task
+
+Run the documentation updater in the requested mode and include only evidence-backed proposals. Do not fabricate or summarize without showing real data.
+
+### Proposed updates
+
+!`~/.agent-os/scripts/update-documentation.sh --dry-run $ARGUMENTS`
+
+If flags are provided, pass them through; otherwise default to `--dry-run`.
+
+## Notes
+
+- This is a core user-level command. It calls the shared updater installed at `~/.agent-os/scripts/update-documentation.sh`.
+- Use this before PR creation and after completing a task to surface required doc updates.
+

--- a/docs/CLAUDE_CODE_BEST_PRACTICES.md
+++ b/docs/CLAUDE_CODE_BEST_PRACTICES.md
@@ -1,0 +1,205 @@
+# Getting Claude to Behave Like a Senior Developer
+
+## The Problem Pattern
+
+Claude (especially Claude Code) exhibits consistent problematic behaviors when working on codebases:
+
+### Common Misbehaviors
+1. **Rushing to create specs/plans** before understanding existing code
+2. **Ignoring the README.md** even when explicitly told to "examine the repo"
+3. **Making assumptions** instead of verifying what's already implemented
+4. **Documenting problems** instead of fixing them
+5. **Apologizing profusely** when caught, then repeating the same mistakes
+
+### Real Examples of Claude Misbehaving
+
+#### Example 1: Ignoring Existing PostgreSQL Implementation
+```
+User: "I want to make sure that you see and understand the current repo and the 
+postgres work that is here and has been done. are we in sync?"
+
+Claude: [Immediately starts creating a new spec and plan for PostgreSQL migration]
+
+[Only after being prompted, Claude actually examines the repo and discovers:]
+"The PostgreSQL migration work is already complete! We just need to focus on
+production deployment and verification."
+
+User: "Why didn't you examine the current state before leaping ahead?"
+
+Claude: "You're absolutely right. I apologize for jumping ahead with creating a spec
+without first examining what was already implemented. That was a significant
+oversight on my part."
+```
+
+#### Example 2: Skipping README Despite Clear Instructions
+```
+User Rules: 
+1. Thoroughly **examine the repo** and summarize what already exists.
+2. Identify what the **open issue actually requires**
+3. Only after steps 1 and 2, propose next steps.
+
+Claude: [Completely skips README.md, makes assumptions, starts proposing work]
+
+[After being corrected:]
+"You are absolutely right, and I apologize for completely failing to follow your 
+clear rules. When you said 'Thoroughly examine the repo' - of course that should 
+have included reading the README.md first. The README is literally the entry point..."
+
+[Claude then lists all the critical information that was in the README that it missed]
+```
+
+## Why This Happens
+
+Claude appears to have:
+- **Action bias**: Wanting to demonstrate value by creating/doing rather than reading/understanding
+- **Assumption tendency**: Making guesses to move faster instead of verifying
+- **Production over analysis**: Generating new content feels more "productive" than examining existing content
+
+## Effective Strategies to Fix This
+
+### 1. The Blocking Checklist Approach
+
+```markdown
+STOP. Do not write any analysis, specs, or suggestions yet.
+
+First, complete this checklist:
+□ Read README.md in full
+□ Read any docs/ directory files  
+□ Check package.json/requirements.txt for dependencies
+□ Examine the file structure
+□ Read the issue description carefully
+
+Reply ONLY with what you found. No suggestions. No analysis. Just findings.
+```
+
+### 2. The Phase-Gate Method
+
+```markdown
+PHASE 1: DISCOVERY (Complete this entire phase before any analysis)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Required examination checklist - check each item and show me what you find:
+□ README.md - What does it say about current features and deployment?
+□ Issue description - Quote the EXACT requirements (not a summary)
+□ Package.json/requirements.txt - What libraries are already installed?
+□ Routes/endpoints - What API endpoints exist?
+□ Frontend components - What components already exist?
+□ Database schema - What data structures are already defined?
+□ Tests - What test coverage exists?
+□ Documentation - Any relevant docs?
+□ Production deployment - Check the live site for existing features
+
+For each item above, paste relevant snippets or write "Not found" if absent.
+Do NOT interpret, analyze, or suggest anything yet. Just show me what exists.
+
+PHASE 2: ANALYSIS (Only after I confirm Phase 1 is complete)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[Only unlock after Phase 1 review]
+```
+
+### 3. The Senior Developer Framing
+
+```markdown
+You are a senior developer conducting a code review.
+
+SENIOR DEVELOPER RULE: A junior developer assumes and builds. 
+A senior developer investigates first. Be senior.
+
+Your audit task:
+1. Find and document EVERY piece of existing code related to [feature]
+2. Read the issue and list each requirement as a checkbox
+3. For each requirement, annotate with:
+   ✅ Fully implemented (show where)
+   ⚠️ Partially implemented (show what exists)
+   ❌ Not implemented
+   ❓ Unclear (needs clarification)
+
+Remember: You're looking for reasons to REJECT duplicate work, 
+not reasons to build new things.
+```
+
+### 4. The Two-Message Force
+
+Break discovery and planning into separate messages:
+
+**Message 1:**
+```markdown
+Read and summarize ONLY the README.md. Nothing else. 
+Show me you understand what's already deployed.
+```
+
+**Message 2 (only after Claude responds):**
+```markdown
+Now examine the rest of the codebase and tell me what exists.
+After you show me your findings, I'll ask for next steps in a separate message.
+```
+
+## For Fixing Problems (Not Just Documenting Them)
+
+When Claude documents issues but doesn't fix them:
+
+### The Resolution Mandate
+
+```markdown
+RESOLUTION PHASE - Do not stop until all checks pass
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+You've identified 3 issues. Fix them one by one and VERIFY each fix:
+
+Issue 1: [Specific issue]
+□ Show me the exact error message
+□ Fix the issue
+□ Run the test/check locally to verify it works
+□ Show me successful output
+
+After EACH fix:
+- Commit with a message explaining what you fixed
+- Run the test/check again to verify it works
+- Show me the passing output
+
+DO NOT move to the next issue until the current one shows green.
+DO NOT summarize what you "would" do - actually do it and show me it working.
+
+A senior developer doesn't document failures - they resolve them.
+```
+
+## Key Phrases That Work
+
+### Prevention
+- "Do not write any analysis, specs, or suggestions yet"
+- "Reply ONLY with what you found. No suggestions."
+- "Show me exactly what you find, with file paths and relevant code snippets"
+- "A junior developer assumes and builds. A senior developer investigates first."
+
+### Forcing Completion
+- "Do not stop until all checks pass"
+- "DO NOT move to the next issue until the current one shows green"
+- "No status updates needed - just show me green checks"
+- "A senior developer doesn't document failures - they resolve them"
+
+## The Ultimate Pattern
+
+1. **Make examination a blocking requirement** - Can't proceed without it
+2. **Require evidence, not claims** - Show snippets, not summaries
+3. **Separate phases explicitly** - Discovery first, planning only after confirmation
+4. **Frame as senior developer work** - Investigation over assumption
+5. **Define success concretely** - "All green checks" not "issues addressed"
+
+## Common Failure Modes to Watch For
+
+Even with good instructions, watch for Claude:
+- Saying it "would" do something instead of doing it
+- Summarizing findings instead of showing actual code/content
+- Moving to the next step before verifying the current step works
+- Apologizing and promising to do better (without actually changing behavior)
+- Creating new specs/plans in the middle of discovery phase
+
+## The Most Important Rule
+
+**Never let Claude proceed to planning/building until it has demonstrated complete understanding of what already exists.**
+
+The README.md should ALWAYS be the first thing examined. If Claude skips it, stop everything and start over.
+
+---
+
+*Remember: Claude's apologies don't prevent repeated mistakes. Only structural barriers in your prompts do.*

--- a/instructions/core/execute-task.md
+++ b/instructions/core/execute-task.md
@@ -166,6 +166,22 @@ Update tasks.md immediately after completing the task.
 
 </step>
 
+<step number="8" name="documentation_sync">
+
+### Step 8: Documentation Sync (Read-only by default)
+
+Run the core slash command to surface evidence-backed documentation updates.
+
+<instructions>
+  ACTION: `/update-documentation --dry-run`
+  RESULT: Show proposed doc updates based on real diffs (no fabrication)
+  OPTION: If user approves and evidence exists, rerun with `--create-missing` to scaffold required docs
+  NOTE: Do not write without explicit approval
+  EVIDENCE: Include output in PR under "Documentation Updates"
+  </instructions>
+
+</step>
+
 <conditional_steps>
   <security_review subagent="security-threat-analyst">
     <trigger>auth, user data, input handling</trigger>

--- a/instructions/hygiene-check.md
+++ b/instructions/hygiene-check.md
@@ -94,6 +94,39 @@ encoding: UTF-8
 
 </step>
 
+<step number="6" name="documentation_drift_report">
+
+### Step 6: Documentation Drift (Non-blocking)
+
+<step_metadata>
+  <checks>diff-driven documentation needs</checks>
+  <reports>expected updates for CHANGELOG/README/docs/product</reports>
+  <non_blocking>true</non_blocking>
+</step_metadata>
+
+<drift_checks>
+  <diff_list>git diff --name-only HEAD</diff_list>
+  <mapping>
+    <changelog>if scripts/tools/instructions/hooks changed → CHANGELOG.md</changelog>
+    <readme>if tools/setup/README/CLAUDE changed → README.md, CLAUDE.md</readme>
+    <product>if instructions/product changed → .agent-os/product/{roadmap.md,decisions.md}</product>
+    <docs>if instructions/workflow-modules changed → docs/**</docs>
+  </mapping>
+</drift_checks>
+
+<drift_report_template>
+  ## 📝 Documentation Drift
+
+  [IF_NONE]
+  No doc updates inferred from recent diffs.
+
+  [IF_SOME]
+  The following docs likely require updates:
+  - [LIST_TARGETS]
+  Recommended: run `/update-documentation --dry-run` to view proposals.
+</drift_report_template>
+
+</step>
 <step number="2" name="github_status_assessment">
 
 ### Step 2: GitHub Issues & PRs Assessment

--- a/scripts/update-documentation.sh
+++ b/scripts/update-documentation.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Agent OS Documentation Updater (discovery-first; evidence-only)
+
+set -euo pipefail
+
+MODE="dry-run"
+CREATE_MISSING=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) MODE="dry-run" ;;
+    --diff-only) MODE="diff-only" ;;
+    --create-missing) CREATE_MISSING=1 ;;
+  esac
+done
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$repo_root"
+
+changed=$(git diff --name-only HEAD 2>/dev/null || true)
+
+echo "# Discovery"
+if [[ -z "$changed" ]]; then
+  echo "No changes detected."
+  exit 0
+fi
+echo "$changed" | sed 's/^/- /'
+
+needs_changelog=0; needs_readme=0; needs_product=0; needs_docs=0
+echo "$changed" | grep -qE "^(scripts/|tools/|setup\.sh|setup-claude-code\.sh|setup-cursor\.sh|hooks/|instructions/|workflow-modules/)" && needs_changelog=1
+echo "$changed" | grep -qE "^(tools/|setup\.sh|README\.md|CLAUDE\.md)" && needs_readme=1
+echo "$changed" | grep -qE "^(instructions/|workflow-modules/)" && needs_docs=1
+echo "$changed" | grep -qE "^(\.agent-os/product/|instructions/core/execute-tasks\.md|instructions/core/execute-task\.md)" && needs_product=1
+
+echo ""
+echo "# Proposed Documentation Updates"
+
+proposals=()
+[[ $needs_changelog -eq 1 ]] && proposals+=("CHANGELOG.md")
+[[ $needs_readme -eq 1 ]] && proposals+=("README.md" "CLAUDE.md")
+[[ $needs_docs -eq 1 ]] && proposals+=("docs/*")
+[[ $needs_product -eq 1 ]] && proposals+=(".agent-os/product/{roadmap.md,decisions.md}")
+
+if [[ ${#proposals[@]} -eq 0 ]]; then
+  echo "No documentation changes required by heuristics."
+  exit 0
+fi
+
+printf '%s\n' "${proposals[@]}" | sed 's/^/- /'
+
+missing=()
+for target in CHANGELOG.md README.md CLAUDE.md \
+              .agent-os/product/roadmap.md .agent-os/product/decisions.md; do
+  if printf '%s\n' "${proposals[@]}" | grep -q "$target"; then
+    [[ ! -f "$target" ]] && missing+=("$target")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo ""
+  echo "# Missing Required Docs"
+  printf '%s\n' "${missing[@]}" | sed 's/^/- /'
+  if [[ $CREATE_MISSING -eq 1 && "$MODE" != "diff-only" ]]; then
+    echo ""
+    echo "# Creating minimal scaffolds (References only)"
+    for f in "${missing[@]}"; do
+      mkdir -p "$(dirname "$f")"
+      {
+        echo "# $(basename "$f" .md | tr '-' ' ' | sed 's/.*/\u&/')"
+        echo ""
+        echo "## References"
+        echo "- Diff: see 'git diff --name-only HEAD'"
+      } > "$f"
+      echo "Created $f"
+    done
+  fi
+fi
+
+if [[ "$MODE" == "dry-run" ]]; then
+  # Fail (exit 2) if proposals exist to signal CI/Hook without writing
+  if [[ ${#proposals[@]} -gt 0 ]]; then exit 2; fi
+  exit 0
+fi
+
+if [[ "$MODE" == "diff-only" ]]; then
+  git --no-pager diff --stat
+  exit 0
+fi
+
+exit 0
+

--- a/setup-claude-code.sh
+++ b/setup-claude-code.sh
@@ -36,7 +36,7 @@ echo ""
 echo "📥 Downloading Claude Code command files to ~/.claude/commands/"
 
 # Commands
-for cmd in plan-product create-spec execute-tasks analyze-product hygiene-check; do
+for cmd in plan-product create-spec execute-tasks analyze-product hygiene-check update-documentation; do
     if [ -f "$HOME/.claude/commands/${cmd}.md" ]; then
         echo "  ⚠️  ~/.claude/commands/${cmd}.md already exists - skipping"
     else


### PR DESCRIPTION
# Evidence: dry-run output

```bash
scripts/update-documentation.sh --dry-run
```

```
# Discovery
- commands/update-documentation.md
- docs/CLAUDE_CODE_BEST_PRACTICES.md
- hooks/workflow-enforcement-hook.py
- instructions/core/execute-task.md
- instructions/hygiene-check.md
- scripts/update-documentation.sh
- setup-claude-code.sh

# Proposed Documentation Updates
- CHANGELOG.md
- docs/*
- .agent-os/product/{roadmap.md,decisions.md}

```
