### PR TITLE
feat: /update-documentation --deep (evidence-first audit)

### DIFF
--- a/commands/update-documentation.md
+++ b/commands/update-documentation.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(grep:*), Bash(sed:*), Bash(awk:*), Bash(~/.agent-os/scripts/update-documentation.sh:*)
 description: Update project documentation deterministically based on real diffs (discovery-first; evidence only)
-argument-hint: [--dry-run|--diff-only|--create-missing]
+argument-hint: [--dry-run|--diff-only|--create-missing|--deep]
 ---
 
 ## Context
@@ -22,5 +22,6 @@ If flags are provided, pass them through; otherwise default to `--dry-run`.
 ## Notes
 
 - This is a core user-level command. It calls the shared updater installed at `~/.agent-os/scripts/update-documentation.sh`.
+- Use `--deep` to run a senior-style, evidence-first audit that detects non-obvious documentation drift and outputs cited proposals.
 - Use this before PR creation and after completing a task to surface required doc updates.
 

--- a/hooks/workflow-enforcement-hook.py
+++ b/hooks/workflow-enforcement-hook.py
@@ -290,7 +290,8 @@ def handle_posttool(input_data):
         # Run updater in dry-run to detect pending docs (exit 2 means proposals exist)
         result = subprocess.run([
             os.path.expanduser("~/.agent-os/scripts/update-documentation.sh"),
-            "--dry-run"
+            "--dry-run",
+            "--deep"
         ], capture_output=True, text=True, timeout=10)
         if result.returncode == 2:
             msg = (


### PR DESCRIPTION
Adds --deep mode to detect non-obvious documentation drift with evidence-only proposals. Integrates with slash command and hook.\n\nEvidence:\n\n```bash\n~/.agent-os/scripts/update-documentation.sh --dry-run --deep || true\n```