### PR TITLE
docs/install: /update-documentation docs + setup install + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Instruction Structure & Orchestrator**
   - `instructions/core/` and `instructions/meta/` restored as source of truth with XML tags
   - `instructions/core/execute-tasks.md` adds Phase 0 Repository Discovery Gate and PR evidence requirements
+  - Added Phase 1.5 Deep Reality Check (Dev/Test/Prod) with citations; Phase 0 verification scripts pre-check; Phase 4 PR evidence-only fallback after repeated violations (PR #45)
 
 ### Changed
 - **Versioning**: Canonical version file is `~/.agent-os/VERSION` (uppercase); CLI and docs updated

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Why these changes: to stop fabricated success claims, prevent shortcuts that div
 
 Docs, installation, useage, & best practices 👉 [It's all here](https://buildermethods.com/agent-os)
 
+#### Core Slash Commands (Claude Code)
+
+```bash
+# Documentation updater (discovery-first; evidence-only)
+/update-documentation --dry-run         # standard proposals
+/update-documentation --deep --dry-run  # deep evidence audit (Dev/Test/Prod)
+# Install via: curl -sSL https://raw.githubusercontent.com/carmandale/agent-os/main/setup-claude-code.sh | bash
+```
+
 ---
 
 ### Created by Brian Casel @ Builder Methods

--- a/setup.sh
+++ b/setup.sh
@@ -166,6 +166,11 @@ curl -s -o "$HOME/.agent-os/scripts/task-validator.sh" "${BASE_URL}/scripts/task
 chmod +x "$HOME/.agent-os/scripts/task-validator.sh"
 echo "  ✓ ~/.agent-os/scripts/task-validator.sh"
 
+# update-documentation.sh (deterministic docs updater)
+curl -s -o "$HOME/.agent-os/scripts/update-documentation.sh" "${BASE_URL}/scripts/update-documentation.sh"
+chmod +x "$HOME/.agent-os/scripts/update-documentation.sh"
+echo "  ✓ ~/.agent-os/scripts/update-documentation.sh"
+
 # config-resolver.py
 curl -s -o "$HOME/.agent-os/scripts/config-resolver.py" "${BASE_URL}/scripts/config-resolver.py"
 echo "  ✓ ~/.agent-os/scripts/config-resolver.py"


### PR DESCRIPTION
- README: document core slash command and deep mode\n- setup.sh: install update-documentation.sh to ~/.agent-os/scripts\n- CHANGELOG: note execute-tasks guardrails (PR #45)\n\nEvidence: textual changes + installer step. CI will verify.