### PR TITLE
fix: enforce CHANGELOG updates across repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Instruction Structure & Orchestrator**
   - `instructions/core/` and `instructions/meta/` restored as source of truth with XML tags
   - `instructions/core/execute-tasks.md` adds Phase 0 Repository Discovery Gate and PR evidence requirements
+  - Added Phase 1.5 Deep Reality Check (Dev/Test/Prod) with citations; Phase 0 verification scripts pre-check; Phase 4 PR evidence-only fallback after repeated violations (PR #45)
 
 ### Changed
 - **Versioning**: Canonical version file is `~/.agent-os/VERSION` (uppercase); CLI and docs updated

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ Why these changes: to stop fabricated success claims, prevent shortcuts that div
 
 Docs, installation, useage, & best practices 👉 [It's all here](https://buildermethods.com/agent-os)
 
+#### Core Slash Commands (Claude Code)
+
+```bash
+# Documentation updater (discovery-first; evidence-only)
+/update-documentation --dry-run         # standard proposals
+/update-documentation --deep --dry-run  # deep evidence audit (Dev/Test/Prod)
+# Install via: curl -sSL https://raw.githubusercontent.com/carmandale/agent-os/main/setup-claude-code.sh | bash
+```
+
 ---
 
 ### Created by Brian Casel @ Builder Methods

--- a/scripts/update-documentation.sh
+++ b/scripts/update-documentation.sh
@@ -61,7 +61,12 @@ if [[ $DEEP -eq 1 ]]; then
 fi
 
 needs_changelog=0; needs_readme=0; needs_product=0; needs_docs=0
+# Heuristic 1: core Agent OS files likely require CHANGELOG
 echo "$changed" | grep -qE "^(scripts/|tools/|setup\.sh|setup-claude-code\.sh|setup-cursor\.sh|hooks/|instructions/|workflow-modules/)" && needs_changelog=1
+# Heuristic 2: any non-doc change anywhere should update CHANGELOG (generalize for other repos)
+if echo "$changed" | grep -vqE "^(docs/|\.agent-os/product/|\.github/|CHANGELOG\.md$)"; then
+  needs_changelog=1
+fi
 echo "$changed" | grep -qE "^(tools/|setup\.sh|README\.md|CLAUDE\.md)" && needs_readme=1
 echo "$changed" | grep -qE "^(instructions/|workflow-modules/)" && needs_docs=1
 echo "$changed" | grep -qE "^(\.agent-os/product/|instructions/core/execute-tasks\.md|instructions/core/execute-task\.md)" && needs_product=1
@@ -107,6 +112,12 @@ if [[ ${#missing[@]} -gt 0 ]]; then
       } > "$f"
       echo "Created $f"
     done
+  else
+    # Enforce CHANGELOG presence when changes require it
+    if printf '%s\n' "${missing[@]}" | grep -q '^CHANGELOG.md$'; then
+      echo "CHANGELOG.md is required for documenting changes."
+      exit 2
+    fi
   fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -166,6 +166,11 @@ curl -s -o "$HOME/.agent-os/scripts/task-validator.sh" "${BASE_URL}/scripts/task
 chmod +x "$HOME/.agent-os/scripts/task-validator.sh"
 echo "  ✓ ~/.agent-os/scripts/task-validator.sh"
 
+# update-documentation.sh (deterministic docs updater)
+curl -s -o "$HOME/.agent-os/scripts/update-documentation.sh" "${BASE_URL}/scripts/update-documentation.sh"
+chmod +x "$HOME/.agent-os/scripts/update-documentation.sh"
+echo "  ✓ ~/.agent-os/scripts/update-documentation.sh"
+
 # config-resolver.py
 curl -s -o "$HOME/.agent-os/scripts/config-resolver.py" "${BASE_URL}/scripts/config-resolver.py"
 echo "  ✓ ~/.agent-os/scripts/config-resolver.py"


### PR DESCRIPTION
- Broadened heuristic to require CHANGELOG.md for most non-doc changes\n- If missing and not --create-missing, exit 2 in dry-run to block PR\n- Ensures consistency in repos that lacked CHANGELOG.md