### PR TITLE
fix: PreToolUse enforces writes (Edit|Write|MultiEdit|Update|Task)

### DIFF
--- a/hooks/agent-os-bash-hooks.json
+++ b/hooks/agent-os-bash-hooks.json
@@ -12,6 +12,24 @@
             "command": "~/.agent-os/hooks/pre-bash-hook.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit|Update",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.agent-os/hooks/workflow-enforcement-hook.py pretool"
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.agent-os/hooks/workflow-enforcement-hook.py pretool-task"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
- Add PreToolUse matchers for Edit|Write|MultiEdit|Update to call workflow-enforcement-hook.py pretool\n- Add PreToolUse matcher for Task to call pretool-task\n- Ensures write attempts are denied at tool boundary regardless of slash command or 'proceed'