### PR TITLE
feat: add spec for fixing /update-documentation command #40

### DIFF
--- a/.agent-os/specs/2025-08-18-update-documentation-command-#40/spec.md
+++ b/.agent-os/specs/2025-08-18-update-documentation-command-#40/spec.md
@@ -1,0 +1,47 @@
+# Spec Requirements Document
+
+> Spec: Fix /update-documentation Command
+> Created: 2025-08-18
+> GitHub Issue: #40
+> Status: Planning
+
+## Overview
+
+Fix the /update-documentation command to properly detect documentation drift instead of checking database configurations. The command should provide a comprehensive documentation health check for Agent OS installations, validating that all documentation is current, complete, and aligned with actual implementation state.
+
+## User Stories
+
+### Documentation Health Check
+
+As a Agent OS user, I want to run `/update-documentation` to quickly identify documentation drift, so that I can maintain accurate project documentation without manual auditing.
+
+**Workflow**: User runs command → system analyzes documentation completeness → provides actionable report with specific fixes needed → user can address gaps efficiently.
+
+### Deep Documentation Audit
+
+As a Agent OS maintainer, I want to run `/update-documentation --deep` to perform comprehensive documentation validation, so that I can ensure all Agent OS components are properly documented and cross-referenced.
+
+**Workflow**: Maintainer runs deep mode → system performs exhaustive checks across all Agent OS documentation → generates detailed audit report → maintainer can systematically address all documentation issues.
+
+## Spec Scope
+
+1. **Normal Mode Operation** - Quick documentation health check focusing on recent activity and common drift patterns
+2. **Deep Mode Operation** - Comprehensive audit of all Agent OS documentation relationships and completeness  
+3. **Evidence-Based Reporting** - Only report factual findings without fabrication or assumptions
+4. **Agent OS Documentation Focus** - Target core Agent OS files: `.agent-os/product/`, `CHANGELOG.md`, `CLAUDE.md`, `docs/`, GitHub issues/PRs
+5. **Actionable Output** - Provide specific, actionable recommendations for fixing identified issues
+
+## Out of Scope
+
+- Database configuration validation (current broken behavior)
+- Non-Agent OS documentation files
+- Automatic documentation fixes (command only reports issues)
+- Documentation content quality assessment
+- Grammar or style checking
+
+## Expected Deliverable
+
+1. Fixed `/update-documentation` command that properly detects documentation drift
+2. Normal mode provides quick check of recent activity and common issues
+3. Deep mode provides comprehensive audit of all Agent OS documentation relationships
+4. Clear, actionable output that helps users maintain documentation health

--- a/.agent-os/specs/2025-08-18-update-documentation-command-#40/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2025-08-18-update-documentation-command-#40/sub-specs/technical-spec.md
@@ -1,0 +1,56 @@
+# Technical Specification
+
+This is the technical specification for the spec detailed in @.agent-os/specs/2025-08-18-update-documentation-command-#40/spec.md
+
+> Created: 2025-08-18
+> Version: 1.0.0
+
+## Technical Requirements
+
+### Command Interface
+- Maintain existing `/update-documentation` command interface
+- Add `--deep` flag for comprehensive audit mode  
+- Preserve output format compatibility for existing users
+- Return appropriate exit codes (0 for clean, 1 for issues found)
+
+### Normal Mode Functionality
+- Check recent commits in CHANGELOG.md (last 30 days)
+- Verify open issues have corresponding specs in `.agent-os/specs/`
+- Check that recent PRs are documented in CHANGELOG.md
+- Validate core Agent OS files exist and are readable
+- Report common documentation drift patterns
+
+### Deep Mode Functionality  
+- Cross-reference all GitHub issues with specs
+- Validate all spec references point to existing files
+- Check roadmap items against actual implementation
+- Verify all Claude Code commands are documented
+- Validate all file references in Agent OS documentation
+- Check `.agent-os/product/` completeness
+
+### Evidence-Based Operation
+- Only report factual findings from actual file analysis
+- No assumptions or fabricated recommendations
+- Show specific file paths and line numbers where applicable
+- Provide exact command outputs and git information
+- Clear separation between facts and suggestions
+
+## Approach Options
+
+**Option A:** Shell Script Implementation (Selected)
+- Pros: Consistent with Agent OS architecture, no new dependencies, fast execution
+- Cons: More complex for deep file analysis, limited JSON processing
+
+**Option B:** Python Script Implementation  
+- Pros: Better text processing, easier JSON/YAML parsing, more robust file analysis
+- Cons: Adds Python dependency, inconsistent with shell-first Agent OS approach
+
+**Rationale:** Shell script maintains architectural consistency while leveraging existing Agent OS patterns. Complex analysis can use standard Unix tools (grep, awk, jq).
+
+## External Dependencies
+
+- **jq** (for JSON processing of GitHub API responses)
+- **gh CLI** (for GitHub issue/PR data - already required by Agent OS)
+- **git** (for commit analysis - already required by Agent OS)
+
+**Justification:** All dependencies are already required by Agent OS core functionality, so no new external dependencies are introduced.

--- a/.agent-os/specs/2025-08-18-update-documentation-command-#40/sub-specs/tests.md
+++ b/.agent-os/specs/2025-08-18-update-documentation-command-#40/sub-specs/tests.md
@@ -1,0 +1,50 @@
+# Tests Specification
+
+This is the tests coverage details for the spec detailed in @.agent-os/specs/2025-08-18-update-documentation-command-#40/spec.md
+
+> Created: 2025-08-18
+> Version: 1.0.0
+
+## Test Coverage
+
+### Unit Tests
+
+**Documentation Analysis Functions**
+- Test CHANGELOG.md parsing for recent entries
+- Test spec directory scanning and validation
+- Test file reference validation logic
+- Test GitHub issue/PR data processing
+- Test normal vs deep mode flag handling
+
+**File System Operations**
+- Test handling of missing files gracefully
+- Test permission errors on documentation files
+- Test malformed JSON/YAML parsing
+- Test edge cases in git log parsing
+
+### Integration Tests
+
+**Normal Mode Workflow**
+- Test complete normal mode execution on clean documentation
+- Test detection of missing CHANGELOG entries
+- Test detection of issues without specs
+- Test handling of mixed clean/dirty documentation state
+
+**Deep Mode Workflow** 
+- Test comprehensive audit on complete Agent OS installation
+- Test detection of broken file references
+- Test cross-referencing between roadmap and specs
+- Test handling of large documentation sets
+
+**Command Interface**
+- Test `/update-documentation` command integration
+- Test `--deep` flag behavior
+- Test output format consistency
+- Test exit code behavior for different scenarios
+
+### Mocking Requirements
+
+- **GitHub CLI responses** - Mock `gh issue list` and `gh pr list` output for consistent testing
+- **Git log output** - Mock git commit history for changelog validation tests  
+- **File system state** - Mock various documentation completeness scenarios
+- **Agent OS installation** - Mock different Agent OS configuration states for testing


### PR DESCRIPTION
## Summary
Adds specification for fixing the /update-documentation command's deep mode.

**Relates to #40**

## Changes
- Created spec directory for Issue #40
- Defined requirements for normal and deep modes
- Outlined technical approach to replace postgres/sqlite checks with actual documentation drift detection

## Why Merge This?
- Just planning/documentation - no code changes
- Allows fresh start on implementation with clean spec
- Any developer can pick up Issue #40 with clear requirements

## Next Steps
After merge, implementation can begin on a fresh branch following the spec.